### PR TITLE
ビューのindexで94行目showリンクをid無しで飛べるよう修正

### DIFF
--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -91,7 +91,7 @@
           = link_to "新規投稿商品"
       .productLists
         .productList
-          = link_to item_path do
+          = link_to 'items/show' do
             %figure.productList--img
               = image_tag asset_path("https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"), alt: "a007.png"
             .productList--body


### PR DESCRIPTION
# what
「= link_to item_path do」を一時的に「= link_to 'items/show' do」に修正した
※ピックアップカテゴリーの「product3」の画像です

# why
本番環境動作確認する為に実施した